### PR TITLE
Compile and runtime fixes

### DIFF
--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -39,6 +39,10 @@
 #define MIN_MYSQL_SERVER_VERSION 50100u
 #define MIN_MYSQL_CLIENT_VERSION 50100u
 
+#ifndef MYSQL_SERVER_VERSION
+#define MYSQL_SERVER_VERSION MARIADB_BASE_VERSION
+#endif
+
 class PingOperation : public SQLOperation
 {
     //! Operation for idle delaythreads

--- a/src/server/database/Database/MySQLConnection.cpp
+++ b/src/server/database/Database/MySQLConnection.cpp
@@ -503,7 +503,9 @@ bool MySQLConnection::_HandleMySQLErrno(uint32 errNo, uint8 attempts /*= 5*/)
     {
         case CR_SERVER_GONE_ERROR:
         case CR_SERVER_LOST:
+#ifdef CR_INVALID_CONN_HANDLE
         case CR_INVALID_CONN_HANDLE:
+#endif
         case CR_SERVER_LOST_EXTENDED:
         {
             if (m_Mysql)

--- a/src/server/game/AI/NpcBots/bot_death_knight_ai.cpp
+++ b/src/server/game/AI/NpcBots/bot_death_knight_ai.cpp
@@ -1314,8 +1314,8 @@ public:
                     CastSpellExtraArgs extra;
                     extra.TriggerFlags = TriggerCastFlags::TRIGGERED_FULL_MASK;
                     extra.AddSpellMod(SPELLVALUE_BASE_POINT0, bp0);
-                    extra.AddSpellMod(SPELLVALUE_BASE_POINT1, NULL);
-                    extra.AddSpellMod(SPELLVALUE_BASE_POINT2, NULL);
+                    extra.AddSpellMod(SPELLVALUE_BASE_POINT1, 0);
+                    extra.AddSpellMod(SPELLVALUE_BASE_POINT2, 0);
                     me->CastSpell(me, BLOOD_PRESENCE_HEAL_EFFECT, extra);
                 }
             }

--- a/src/server/game/AI/NpcBots/bot_paladin_ai.cpp
+++ b/src/server/game/AI/NpcBots/bot_paladin_ai.cpp
@@ -908,8 +908,8 @@ public:
                     CastSpellExtraArgs extra;
                     extra.TriggerFlags = TriggerCastFlags::TRIGGERED_FULL_MASK;
                     extra.AddSpellMod(SPELLVALUE_BASE_POINT0, basepoints);
-                    extra.AddSpellMod(SPELLVALUE_BASE_POINT1, NULL);
-                    extra.AddSpellMod(SPELLVALUE_BASE_POINT2, NULL);
+                    extra.AddSpellMod(SPELLVALUE_BASE_POINT1, 0);
+                    extra.AddSpellMod(SPELLVALUE_BASE_POINT2, 0);
                     me->CastSpell(me, SPIRITUAL_ATTUNEMENT_ENERGIZE, extra);
                 }
             }

--- a/src/server/game/AI/NpcBots/bot_rogue_ai.cpp
+++ b/src/server/game/AI/NpcBots/bot_rogue_ai.cpp
@@ -275,8 +275,8 @@ public:
                 CastSpellExtraArgs extra;
                 extra.TriggerFlags = TriggerCastFlags::TRIGGERED_NONE;
                 extra.AddSpellMod(SPELLVALUE_BASE_POINT0, damage);
-                extra.AddSpellMod(SPELLVALUE_BASE_POINT1, NULL);
-                extra.AddSpellMod(SPELLVALUE_BASE_POINT2, NULL);
+                extra.AddSpellMod(SPELLVALUE_BASE_POINT1, 0);
+                extra.AddSpellMod(SPELLVALUE_BASE_POINT2, 0);
                 me->CastSpell(me, EVISCERATE, extra);
                 return;
             }
@@ -319,8 +319,8 @@ public:
                 CastSpellExtraArgs extra;
                 extra.TriggerFlags = TriggerCastFlags::TRIGGERED_NONE;
                 extra.AddSpellMod(SPELLVALUE_BASE_POINT0, damage);
-                extra.AddSpellMod(SPELLVALUE_BASE_POINT1, NULL);
-                extra.AddSpellMod(SPELLVALUE_BASE_POINT2, NULL);
+                extra.AddSpellMod(SPELLVALUE_BASE_POINT1, 0);
+                extra.AddSpellMod(SPELLVALUE_BASE_POINT2, 0);
                 me->CastSpell(me, RUPTURE, extra);
                 return;
             }

--- a/src/server/game/Spells/SpellDefines.h
+++ b/src/server/game/Spells/SpellDefines.h
@@ -166,13 +166,13 @@ struct TC_GAME_API CastSpellExtraArgs
     CastSpellExtraArgs(AuraEffect const* eff) : TriggerFlags(TRIGGERED_FULL_MASK), TriggeringAura(eff) {}
     CastSpellExtraArgs(ObjectGuid const& origCaster) : TriggerFlags(TRIGGERED_FULL_MASK), OriginalCaster(origCaster) {}
     CastSpellExtraArgs(AuraEffect const* eff, ObjectGuid const& origCaster) : TriggerFlags(TRIGGERED_FULL_MASK), TriggeringAura(eff), OriginalCaster(origCaster) {}
-    CastSpellExtraArgs(SpellValueMod mod, int32 val) { AddSpellMod(mod, val); }
+    CastSpellExtraArgs(SpellValueMod mod, int32 val) { SpellValueOverrides.AddMod(mod, val); }
 
     CastSpellExtraArgs& SetTriggerFlags(TriggerCastFlags flag) { TriggerFlags = flag; return *this; }
     CastSpellExtraArgs& SetCastItem(Item* item) { CastItem = item; return *this; }
     CastSpellExtraArgs& SetTriggeringAura(AuraEffect const* triggeringAura) { TriggeringAura = triggeringAura; return *this; }
     CastSpellExtraArgs& SetOriginalCaster(ObjectGuid const& guid) { OriginalCaster = guid; return *this; }
-    CastSpellExtraArgs& AddSpellMod(SpellValueMod mod, int32 val) { AddSpellMod(mod, val); return *this; }
+    CastSpellExtraArgs& AddSpellMod(SpellValueMod mod, int32 val) { SpellValueOverrides.AddMod(mod, val); return *this; }
     CastSpellExtraArgs& AddSpellBP0(int32 val) { return AddSpellMod(SPELLVALUE_BASE_POINT0, val); } // because i don't want to type SPELLVALUE_BASE_POINT0 300 times
 
     TriggerCastFlags TriggerFlags = TRIGGERED_NONE;

--- a/src/server/scripts/Commands/cs_server.cpp
+++ b/src/server/scripts/Commands/cs_server.cpp
@@ -49,6 +49,10 @@ EndScriptData */
 #include <openssl/crypto.h>
 #include <openssl/opensslv.h>
 
+#ifndef MYSQL_SERVER_VERSION
+#define MYSQL_SERVER_VERSION MARIADB_BASE_VERSION
+#endif
+
 class server_commandscript : public CommandScript
 {
 public:

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -204,8 +204,8 @@ class spell_pal_ardent_defender : public SpellScriptLoader
                         CastSpellExtraArgs extra;
                         extra.TriggerFlags = TriggerCastFlags::TRIGGERED_FULL_MASK;
                         extra.AddSpellMod(SPELLVALUE_BASE_POINT0, healAmount);
-                        extra.AddSpellMod(SPELLVALUE_BASE_POINT1, NULL);
-                        extra.AddSpellMod(SPELLVALUE_BASE_POINT2, NULL);
+                        extra.AddSpellMod(SPELLVALUE_BASE_POINT1, 0);
+                        extra.AddSpellMod(SPELLVALUE_BASE_POINT2, 0);
                         extra.CastItem = NULL;
                         extra.TriggeringAura = aurEff;
                         victim->CastSpell(victim, PAL_SPELL_ARDENT_DEFENDER_HEAL, extra);


### PR DESCRIPTION
This PR includes the following fixes:
- Compatibility with MariaDB 10.2
- Removed an infinitely recursive call to AddSpellMod, which would segfault during combat
- Player entity: fix segfault caused by SmartQuest system (the m_deliverCheck data member would be accessed improperly when picking up the last of certain quest items)
- Other: Replace NULL parameter with 0 in calls to AddSpellMod, as the type is a 32-bit integer